### PR TITLE
Adds UDF that increments proto def indexes

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -122,6 +122,21 @@ function MkSesh(...)
 endfunction
 com -nargs=* MkSesh call MkSesh(<q-args>)
 
+" Renumber proto defs.
+function! Pnum(...) range
+    let idx = a:0 > 0 ? a:1 : 1
+    for linenum in range(a:firstline, a:lastline)
+        " set index of the attribute.
+        let curr_line = getline(linenum)
+        if curr_line =~ '\s\d\+;'
+            let replacement = substitute(curr_line, '\s\d\+;', ' '.idx.';', 'g')
+            call setline(linenum, replacement)
+            let idx += 1
+        endif
+    endfor
+endfunction
+com -nargs=* -range Pnum <line1>,<line2>call Pnum(<f-args>)
+
 " VUNDLE:
 set rtp+=~/.vim/bundle/vundle/
 call vundle#rc()


### PR DESCRIPTION
This vimscript adds a `Pnum` function which will increment protobuf attribute indexes within a selected region of text.